### PR TITLE
Enhance docs and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,14 @@ Parallel CBS Transformer based ASR system built on ESPnet
 fujielab-asr-parallel-cbs is an automatic speech recognition (ASR) system based on ESPnet, featuring a parallelizable Contextual Block Streaming (CBS) Transformer.
 
 ## Features
-- Implementation of a parallel CBS Transformer Encoder extending the ESPnet framework
+- Implementation of a parallel CBS Transformer encoder extending the ESPnet framework
 - Supports online and streaming ASR inference
+- Pretrained models available via [Hugging Face](https://huggingface.co/)
+- Example script for chunk-by-chunk streaming recognition
+
+## Requirements
+- Python 3.11
+- `torch`, `torchaudio`, and other packages listed in `requirements.txt`
 
 ## Installation
 
@@ -18,8 +24,9 @@ pip install fujielab-asr-parallel-cbs
 ```
 
 ### Local Installation
-1. Install the required Python packages:
+1. Install the dependencies:
    ```bash
+   pip install -r requirements.txt
    pip install -e .
    ```
 2. If there are additional dependencies, please refer to `pyproject.toml`.
@@ -32,8 +39,9 @@ You can perform inference from an audio file using `examples/run_streaming_asr.p
 python examples/run_streaming_asr.py
 ```
 
-It will automatically download the pre-trained model from Hugging Face Hub
-and sample audio files from CSJ (Corpus of Spontaneous Japanese) official site.
+The script streams the input audio in 100&nbsp;ms chunks and prints partial results.
+At the first run it downloads a small example audio (`aps-smp.mp3`) from the CSJ
+corpus and a pretrained model from Hugging Face.
 
 
 ## Directory Structure

--- a/examples/run_streaming_asr.py
+++ b/examples/run_streaming_asr.py
@@ -18,9 +18,9 @@ s2t = Speech2Text.from_pretrained(
 
 if not path.exists("aps-smp.mp3"):
     # Download a sample audio file
-    # from https://clrd.ninjal.ac.jp/csj/sound-f/sps-smp.mp3
+    # from https://clrd.ninjal.ac.jp/csj/sound-f/aps-smp.mp3
     import requests
-    url = "https://clrd.ninjal.ac.jp/csj/sound-f/sps-smp.mp3"
+    url = "https://clrd.ninjal.ac.jp/csj/sound-f/aps-smp.mp3"
     response = requests.get(url)
     with open("aps-smp.mp3", "wb") as f:
         f.write(response.content)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# Core dependencies for fujielab-asr-parallel-cbs
+espnet==202301
+espnet_model_zoo
+torchaudio
+typeguard==2.13.3


### PR DESCRIPTION
## Summary
- clarify features and add Requirements section to README
- update local installation instructions
- fix sample filename in example script
- track sample audio in `.gitignore`
- provide `requirements.txt`
- fix sample audio link and name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_6846751bb774832f99d30794dca71166